### PR TITLE
user 정보에 티어 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,23 +46,68 @@
     <script>
         document.getElementById("login-btn").addEventListener("click", () => {
             let name = document.getElementById("get_name").value;
-            let nickname = document.getElementById("get_nick").value;
+            let nickname = document.getElementById("get_nick").value.replace(/(\s*)/g, '');
             let id = document.getElementById("get_id").value;
             let depart = document.getElementById("get_depart").value;
-            console.log(JSON.stringify({ name, nickname, id, depart }));
-            fetch("/connect", {
-                method: "POST",
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ name, nickname, id, depart })
-            })
 
-            location.href = "./main.html";
-            window.localStorage.setItem("name", name);
-            window.localStorage.setItem("nickname", nickname);
-            window.localStorage.setItem("id", id);
-            window.localStorage.setItem("depart", depart);
+
+            const url = "https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/" + nickname + "?api_key=RGAPI-2e1ce1cf-6ec5-41ae-956a-d38e84664106";
+            const xmlhttp = new XMLHttpRequest();
+            xmlhttp.onreadystatechange = function () {
+                if (xmlhttp.status == 200) {
+                    result = this.responseText;
+
+                    const user_info = JSON.parse(result);
+                    const uid = user_info["id"];
+                    const url2 = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/" + uid + "?api_key=RGAPI-2e1ce1cf-6ec5-41ae-956a-d38e84664106";
+                    const xmlhttp2 = new XMLHttpRequest();
+                    xmlhttp2.onreadystatechange = function () {
+                        if (xmlhttp2.status == 200) {
+                            const user_info2 = JSON.parse(this.responseText);
+                            const tier = user_info2[0]["tier"];
+
+                            const rank = user_info2[0]["rank"];
+                            const point = user_info2[0]["leaguePoints"];
+                            fetch("/connect", {
+                                method: "POST",
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify({ name, nickname, id, depart, tier, rank, point })
+                            }).then(() => {
+                                location.href = "./main.html";
+                                window.localStorage.setItem("name", name);
+                                window.localStorage.setItem("nickname", nickname);
+                                window.localStorage.setItem("id", id);
+                                window.localStorage.setItem("depart", depart);
+                                window.localStorage.setItem("tier", tier);
+                                window.localStorage.setItem("rank", rank);
+                                window.localStorage.setItem("point", point);
+
+
+                            })
+
+                        }
+                    }
+                    xmlhttp2.open("GET", url2, true);
+                    xmlhttp2.send();
+
+
+
+                }
+                else {
+                    console.log("소환사를 찾을 수 없습니다.");
+                }
+            };
+
+            xmlhttp.open("GET", url, true);
+            xmlhttp.send();
+
+
+
+
+
+
 
         })    
     </script>

--- a/public/main.html
+++ b/public/main.html
@@ -12,24 +12,37 @@
     <div class="container" id="top">
         <h1>SKKU.GG</h1>
         <div>
-            <input id="btn" type="button" onclick="location.href='./ranking.html'" value="학교 랭킹 확인">
+            <a href='./ranking.html'> 랭킹 확인 </a>
         </div>
+        <div>
+            <a href='./mypage.html'>내 정보</a>
+        </div>
+        <br>
+        <br>
     </div>
-    <br>
-    <br>
     <div>
-        <h3>전적검색</h3>
-        <form method="get">
-            <div class="form-group">
-                <input class="form-control" placeholder="소환사 이름을 입력하세요." type="text" name="username">
-                <input type="submit" value="검색">
-            </div>
-        </form>
+        <input id="summoner-search" placeholder="소환사 이름을 입력하세요." type="text">
+        <button id="search-btn"> 검색</button>
     </div>
     <br>
     <br>
     <br>
     <script>
+        document.getElementById("search-btn").addEventListener("click", () => {
+            let nick = document.getElementById("summoner-search").value.replace(/(\s*)/g, '');
+            if (nick === "") return;
+            fetch("/search", {
+                method: "POST",
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ nick })
+            })
+
+            location.href = "./searching.html";
+        })
+
+
     </script>
 </body>
 

--- a/public/searching.html
+++ b/public/searching.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <p id="user-name"></p>
+    <p id="user-level"></p>
+    <div id=user-icon></div>
+
+    <p>티어 :
+        <span id="user-tier"></span>
+        <span id="user-rank"></span>
+        <span id="user-point"></span>
+    </p>
+
+    <span id="user-win"></span>승 / <span id="user-loss"></span>패
+
+
+
+
+
+    <script>
+        const api = "RGAPI-2e1ce1cf-6ec5-41ae-956a-d38e84664106";
+
+        window.addEventListener("load", () => {
+            fetch("/search", { method: "GET" })
+                .then((res) => res.json())
+                .then((nickname) => {
+                    const url = "https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/" + nickname["nick"] + "?api_key=RGAPI-2e1ce1cf-6ec5-41ae-956a-d38e84664106";
+                    const xmlhttp = new XMLHttpRequest();
+                    xmlhttp.onreadystatechange = function () {
+                        if (this.status == 200) {
+                            result = this.responseText;
+                            const user_info = JSON.parse(result);
+                            const id = user_info["id"];
+                            const nick = user_info["name"];
+                            const icon = user_info["profileIconId"];
+                            const level = user_info["summonerLevel"];
+                            document.getElementById("user-name").innerHTML = nick;
+                            document.getElementById("user-level").innerHTML = level;
+
+                            const img_src = 'http://ddragon.leagueoflegends.com/cdn/12.21.1/img/profileicon/' + icon + '.png';
+                            let img = document.createElement('img');
+                            img.src = img_src;
+                            img.width = 100;
+                            if (document.getElementById('user-icon').childElementCount === 0) {
+                                document.getElementById('user-icon').appendChild(img);
+                            }
+                            const url2 = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/" + id + "?api_key=RGAPI-2e1ce1cf-6ec5-41ae-956a-d38e84664106";
+                            const xmlhttp2 = new XMLHttpRequest();
+                            xmlhttp2.onreadystatechange = function () {
+                                if (this.status == 200) {
+
+                                    const user_info2 = JSON.parse(this.responseText);
+                                    const tier = user_info2[0]["tier"];
+                                    const rank = user_info2[0]["rank"];
+                                    const point = user_info2[0]["leaguePoints"];
+                                    const win = user_info2[0]["wins"];
+                                    const lose = user_info2[0]["losses"];
+                                    document.getElementById("user-tier").textContent = tier;
+                                    document.getElementById("user-rank").textContent = rank;
+                                    document.getElementById("user-point").innerHTML = point;
+                                    document.getElementById("user-win").innerHTML = win;
+                                    document.getElementById("user-loss").innerHTML = lose;
+                                }
+                            }
+                            xmlhttp2.open("GET", url2, true);
+                            xmlhttp2.send();
+
+
+
+                        }
+                        else {
+                            console.log("소환사를 찾을 수 없습니다.");
+                        }
+                    };
+
+                    xmlhttp.open("GET", url, true);
+                    xmlhttp.send();
+
+
+
+                })
+        })
+
+    </script>
+</body>
+
+</html>

--- a/server.js
+++ b/server.js
@@ -4,18 +4,38 @@ const port = 3000;
 
 app.use(express.json());
 
-let user = [{ name: "김준성", nickname: "hide on bush", id: "2018312075", depart: "소프트웨어학과" }];
+let user = [{ name: "김준성", nickname: "hide on bush", id: "2018312075", depart: "소프트웨어학과", tier: "", rank: "", point: "" }];
 let user_count = 1;
 app.post('/connect', (req, res) => {
-    user.push(req.body);
-    user_count++;
-    console.log(JSON.stringify(user))
-    res.send(200);
+    let flag = 1;
+    user.forEach((e) => {
+        if (e["id"] === req.body["id"]) flag = 0;
+    })
+    if (flag) {
+        user.push(req.body);
+        user_count++;
+        console.log(JSON.stringify(user))
+        res.send(200);
+    }
 })
+setInterval(() => console.log(JSON.stringify(user)), 1000);
 app.use(express.static("public"));
 
 app.listen(port, () => {
     console.log(`Example app listening on port ${port}`);
 })
 
+
+
+
+
+let response = {};
+app.post('/search', (req, res) => {
+    response = req.body;
+    console.log(response);
+})
+
+app.get('/search', (req, res) => {
+    res.send(JSON.stringify(response));
+})
 


### PR DESCRIPTION
# 변경사항
 기존에는 user 정보로 {이름, 소환사명, 학과 ,학번} 만 저장할 수 있었는데

 소환사명으로 라이엇 api를 호출해  해당 소환사의 
 티어(diamond , platinum ...) , 랭크 (I, II, IV,,,) 포인트를 추출하여
 user json 멤버로 추가하였습니다.
 
 따라서 user 정보에는 {이름, 소환사명, 학과, 학번, 티어, 랭크, 포인트} 가 담겨있습니다.


간단한 소환사 검색기능 -> 레벨, 아이콘, 티어, 승/패 까지만 보이도록 구현
![image](https://user-images.githubusercontent.com/50402527/204062896-97e09350-7ead-4f3c-9eae-ba0e9d6f9f24.png)



# 해결해야 할 일
 이 값을 토대로 user 배열을 정렬해서 (티어순으로 sorting)
 ranking.html에 티어별로 유저 랭킹 페이지를 구현해주시면 될것 같습니다. @jhn25 