### PR TITLE
로그인시 티어정보 잘못 가져오는 버그 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,10 +64,39 @@
                     xmlhttp2.onreadystatechange = function () {
                         if (xmlhttp2.status == 200) {
                             const user_info2 = JSON.parse(this.responseText);
-                            const tier = user_info2[0]["tier"];
+                            let tier;
+                            let rank;
+                            let point;
+                            if (user_info2.length === 2) {
+                                if (user_info2[0]["queueType"] === "RANKED_SOLO_5x5") {
+                                    tier = user_info2[0]["tier"];
+                                    rank = user_info2[0]["rank"];
+                                    point = user_info2[0]["leaguePoints"];
+                                }
+                                else {
+                                    tier = user_info2[1]["tier"];
+                                    rank = user_info2[1]["rank"];
+                                    point = user_info2[1]["leaguePoints"];
+                                }
 
-                            const rank = user_info2[0]["rank"];
-                            const point = user_info2[0]["leaguePoints"];
+                            }
+                            else if (user_info2.length === 1) {
+                                if (user_info2[0]["queueType"] === "RANKED_SOLO_5x5") {
+                                    tier = user_info2[0]["tier"];
+                                    rank = user_info2[0]["rank"];
+                                    point = user_info2[0]["leaguePoints"];
+                                }
+                                else {
+                                    tier = "UNRANK";
+                                    rank = "UNRANK";
+                                    point = "UNRANK";
+                                }
+                            }
+                            else {
+                                tier = "UNRANK";
+                                rank = "UNRANK";
+                                point = "UNRANK";
+                            }
                             fetch("/connect", {
                                 method: "POST",
                                 headers: {


### PR DESCRIPTION
# 현상
 #7 
# 원인

라이엇 api로 소환사 정보를 파싱을해올때, 어떨땐 솔로랭크 티어가 들어가고, 어떨땐 자유랭크 티어가 들어가서 발생한 버그였습니다.

# 해결방법
소환사 정보를 가져올때, 솔로랭크티어로만 가져오게 반영하였습니다. 만약 솔로랭크 정보가없다면, tier를 UNRANK로 초기화 해주었습니다.